### PR TITLE
corrections de typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ Les features/[API](https://docs.oracle.com/en/java/javase/11/docs/api/index.html
 - Optional, Stream et Collector
 - List non modifiable: List.of(), List.copyOf(), Collectors.toUnmodifiableList()
 
-L'idée de ce kata est d'implanter un [Lexer](https://en.wikipedia.org/wiki/Lexer) capable de transformer une chaine de caractère en tokens, c-a-d un mélange d'identifiant, de mot-clés, de valeurs numériques, etc. Pour reconnaitre si une chaine de caractère est un des tokens définies, on utilisera des expressions régulières. Le but de ce kata est plus de se focaliser sur l'API que sur l'implantation en elle même, cela tombe bien en Java, le package java.util.regex nous enlèves le poid d'avoir à ce ré-implantant la gestion des expressions régulières.
+L'idée de ce kata est d'implémenter un [Lexer](https://en.wikipedia.org/wiki/Lexer) capable de transformer une chaîne de caractères en tokens, c-a-d un mélange d'identifiants, de mot-clés, de valeurs numériques, etc.
+Pour reconnaître si une chaîne de caractères est un des tokens définis, on utilisera des expressions régulières. 
+Le but de ce kata est plus de se focaliser sur l'API que sur l'implémentation en elle même, cela tombe bien en Java, le package java.util.regex nous enlèves le poids d'avoir à ré-implémenter la gestion des expressions régulières.
 
 Voilà une idée de l'API que l'on veut obtenir
 ```java
@@ -24,9 +26,11 @@ Voilà une idée de l'API que l'on veut obtenir
   System.out.println(lexer.tryParse("200").orElseThrow());   // affiche la valeur entière 200
 ```
 
-Le kata est en deux parties, dans un premier temps, on va batir une API fonctionnelle permettant de faire fonctionner le code ci-dessus. Dans un second temps, on va poser la question de comment rendre le compte un peu plus efficace, en conservant la même API.
+Le kata est en deux parties, dans un premier temps, on va bâtir une API fonctionnelle permettant de faire fonctionner le code ci-dessus. 
+Dans un second temps, on va poser la question de comment rendre le compte un peu plus efficace, en conservant la même API.
 
-De plus, pour garantir que vous n'allez pas dans le mur ou que j'ai pas oublié une exigence, le kata vient avec une serie de tests unitaires [JUnit 5](https://junit.org/junit5/docs/current/user-guide/) qui sert de spécification exécutable (Si vous vous posez la question de si j'ai fait du TDD pour créer les tests et l'implantation, la réponse est non, comme pas mal de monde, j'itère sur le code et les tests en parallèle :) ).
+De plus, pour garantir que vous n'allez pas dans le mur ou que je n'ai pas oublié une exigence, 
+le kata vient avec une série de tests unitaires [JUnit 5](https://junit.org/junit5/docs/current/user-guide/) qui sert de spécification exécutable (Si vous vous posez la question de si j'ai fait du TDD pour créer les tests et l'implémentation, la réponse est non, comme pas mal de monde, j'itère sur le code et les tests en parallèle :) ).
 
 Si vous trouvez qu'il manque un test, vous voulez corriger quelque chose, j'attends vos pull requests.
 

--- a/kata-part2.md
+++ b/kata-part2.md
@@ -1,11 +1,13 @@
 # Kata Retrospective 11 - Partie 2
 
-L'idée de ce kata est d'implanter un [Lexer](https://en.wikipedia.org/wiki/Lexer) capable de transformer une chaine de caractère en un token, c-a-d un identifiant, un mot-clé, une valeur numérique, etc. Pour reconnaitre si une chaine de caractère est un des tokens définis, on utilise des expressions régulières. Le but de ce kata est plus de se focaliser sur l'API que sur l'implantation en elle même, cela tombe bien, en Java le package java.util.regex nous enlèves le poid d'avoir à ré-implantant la gestion des expressions régulières.
+L'idée de ce kata est d'implémenter un [Lexer](https://en.wikipedia.org/wiki/Lexer) capable de transformer une chaîne de caractères en un token, c-a-d un identifiant, un mot-clé, une valeur numérique, etc. 
+Pour reconnaître si une chaîne de caractère est un des tokens définis, on utilise des expressions régulières. 
+Le but de ce kata est plus de se focaliser sur l'API que sur l'implémentation en elle même, cela tombe bien en Java, le package java.util.regex nous enlèves le poids d'avoir à ré-implémenter la gestion des expressions régulières.
 
 Le kata est en deux parties, suivez ce [lien pour la première partie](kata.md).
 
 
-En fait, l'implantation que nous avons jusqu'à présent crée autant d'automates qu'il y a d'expressions régulières,
+En fait, l'implémentation que nous avons jusqu'à présent crée autant d'automates qu'il y a d'expressions régulières,
 ce n'est pas vraiment nécessaire car il est possible de créer un seul automate en faisant un *ou* entre les expression régulières
 et de regarder lorsque le texte `matches` le premier groupe qui a extrait une valeur.
 
@@ -16,15 +18,15 @@ Par exemple, pour le code
         .with("([0-9]+\\.[0-9]*)", Double::parseDouble);
 ```
 On va créer l'automate correspondant à l'expression régulière `([0-9]+) | ([0-9]+\\.[0-9]*)`,
-et si le premier groupe contient une valeur extraite alors on sait que c'est la première expression qui a été reconnu,
-si le second groupe contient une valeur alors on sait que c'est la second expression qui a été reconnu.
+et si le premier groupe contient une valeur extraite alors on sait que c'est la première expression qui a été reconnue,
+si le second groupe contient une valeur alors on sait que c'est la second expression qui a été reconnue.
 
 
 ## Question 6
 
-On va créer une nouvelle méthode `from()` qui prend deux listes en paramètre,
-la liste des expressions régulières et la liste des fonctions a appelée si l'expression régulière correspondant est reconnue
-et renvoie un Lexer qui implante l'algorithme décrit ci-dessus.
+On va créer une nouvelle méthode `from()` qui prend deux listes en paramètres,
+la liste des expressions régulières et la liste des fonctions à appeler si l'expression régulière correspondante est reconnue
+et renvoie un Lexer qui implémentate l'algorithme décrit ci-dessus.
 
 Voici un exemple d'utilisation
 ```java
@@ -38,8 +40,8 @@ Vérifier que les tests unitaires marqués Q6 passent, sinon modifier votre code
 
 ## Question 7
 
-Même si la méthode `from` qui prend deux listes offres un algorithme un peu plus efficace, le bénéfice de cette algorithme
-est perdu si on appel les méthodes `map` ou `or` si le Lexer résultant.
+Même si la méthode `from` qui prend deux listes offre un algorithme un peu plus efficace, le bénéfice de cette algorithme
+est perdu si on appel les méthodes `map` ou `or` sur le Lexer résultant.
 
 Modifier votre code pour faire en sorte qu'un seul automate soit créé même si les méthodes `map` et `or` sont utilisées
 ```java
@@ -53,7 +55,7 @@ Vérifier que les tests unitaires marqués Q7 passent, sinon modifier votre code
 
 ## Question 8
 
-Modifier votre implantation pour qu'un seul automate soit créer par défaut si on utilise le code suivant
+Modifier votre implémentation pour qu'un seul automate soit créé par défaut si on utilise le code suivant
 ```java
   var lexer = Lexer.create()
         .with("([0-9]+)",          Integer::parseInt)
@@ -68,7 +70,7 @@ Vérifier que les tests unitaires marqués Q8 passent, sinon modifier votre code
 Si vous ne l'avez pas déjà remarqué, nous voulons aussi laisser la possibilité de créer des Lexers
 qui ne sont pas liés à des expressions régulières.
 
-Par exemple, un lexer qui accepte n'importe quel texte
+Par exemple, un Lexer qui accepte n'importe quel texte
 ```java
   Lexer<String> lexer1 = text -> Optional.of(text));
 ```
@@ -79,7 +81,7 @@ Vérifier que les tests unitaires marqués Q9 passent, sinon modifier votre code
 
 ## That's all folk !
 
-Voilà c'est fini, j'espère que vous avez aprécié la versalité et la capacité d'expression de Java.
-Maintenant, à vous de jouer, à vous d'écrire un kata fonctionnelle avec Java 11, et faite moi une pull requet
+Voilà c'est fini, j'espère que vous avez apprécié la versatilité et la capacité d'expression de Java.
+Maintenant, à vous de jouer, à vous d'écrire un kata orienté programmation fonctionnelle avec Java 11, et faite moi une pull request
 pour que j'ajoute un lien vers votre kata sur la page de README.
 

--- a/kata.md
+++ b/kata.md
@@ -1,6 +1,8 @@
 # Kata Retrospective 11 - Partie 1
 
-L'idée de ce kata est d'implanter un [Lexer](https://en.wikipedia.org/wiki/Lexer) capable de transformer une chaine de caractère en un token, c-a-d un identifiant, un mot-clé, une valeur numérique, etc. Pour reconnaitre si une chaine de caractère est un des tokens définis, on utilise des expressions régulières. Le but de ce kata est plus de se focaliser sur l'API que sur l'implantation en elle même, cela tombe bien, en Java le package java.util.regex nous enlèves le poid d'avoir à ré-implantant la gestion des expressions régulières.
+L'idée de ce kata est d'implémenter un [Lexer](https://en.wikipedia.org/wiki/Lexer) capable de transformer une chaîne de caractères en un token, c-a-d un identifiant, un mot-clé, une valeur numérique, etc. 
+Pour reconnaître si une chaîne de caractère est un des tokens définis, on utilise des expressions régulières. 
+Le but de ce kata est plus de se focaliser sur l'API que sur l'implémentation en elle même, cela tombe bien en Java, le package java.util.regex nous enlèves le poids d'avoir à ré-implémenter la gestion des expressions régulières.
 
 Le kata est en deux parties, suivez ce [lien pour la seconde partie](kata-part2.md).
 
@@ -9,9 +11,9 @@ Le kata est en deux parties, suivez ce [lien pour la seconde partie](kata-part2.
 
 Une expression régulière est représentée en Java par la classe Pattern.
 - la méthode static [Pattern.compile(regex)](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Pattern.html#compile(java.lang.String)) prend une expression régulière sous forme de String, et construit l'automate correspondant,
-- la méhode [pattern.matcher(text)](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Pattern.html#matcher(java.lang.CharSequence)) créer un Matcher, un curseur sur l'automate qui se déplacera en fonction des caractères contenu dans `text`,
+- la méthode [pattern.matcher(text)](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Pattern.html#matcher(java.lang.CharSequence)) créé un Matcher, un curseur sur l'automate qui se déplacera en fonction des caractères contenu dans `text`,
 - la méthode [matcher.matches()](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Matcher.html#matches()) déplace le curseur et renvoie vrai si le texte est reconnu par l'automate,
-- les méthodes [matcher.groupCount()](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Matcher.html#groupCount()) et [matcher.group(index)](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Matcher.html#group(int)) permet d'extraire les motifs reconnu par les groupes (un [groupe](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Pattern.html#cg) est une partie de l'expression régulière définie par des parenthèses, par convention le groupe 0 correspond à tout le texte).
+- les méthodes [matcher.groupCount()](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Matcher.html#groupCount()) et [matcher.group(index)](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Matcher.html#group(int)) permettent d'extraire les motifs reconnu par les groupes (un [groupe](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Pattern.html#cg) est une partie de l'expression régulière définie par des parenthèses, par convention le groupe 0 correspond à tout le texte).
 
 Par exemple, une exécution du code suivant
 ```java
@@ -22,22 +24,22 @@ Par exemple, une exécution du code suivant
 ``` 
 affiche `true` car zoo est bien reconnu par le pattern [a-z]oo puis `zo` car le group 1 a capturé les lettres z et o (celles entre parenthèses).
 
-Note: il n'existe pas de moyen direct de demander à Pattern combien il y a de groupes dans l'expression régulière qui a servi à créer le Pattern, il faut créer un Matcher puis faire un groupCount.
+Note: il n'existe pas de moyen direct de demander à Pattern combien il y a de groupes dans l'expression régulière qui a servi à créer le Pattern, il faut créer un Matcher puis faire un `groupCount`.
 
 
 ## Question 1
 
-Un Lexer est un objet qui est configuré avec des expressions régulières et qui indique si un texte peut être transformer ou non en token.
+Un Lexer est un objet qui est configuré avec des expressions régulières et qui indique si un texte peut être transformé ou non en token.
 De façon abstraite, c'est une fonction qui prend un texte en entrée et qui 
 - soit renvoie un token (on va dire un T comme cela, cela marchera avec n'importe quoi)
 - soit renvoie rien si le texte n'est pas reconnu.
 
 Note: "un truc ou rien" en Java, c'est un [Optional](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/Optional.html) .
 
-On va dans un premier temps, créer un Lexer (avec la méthode `create`) qui quelque soit le texte, ne le reconnait pas,
+On va dans un premier temps, créer un Lexer (avec la méthode `create`) qui quelque soit le texte, ne le reconnaît pas,
 ça à pas l'air super utile mais cela permet d'avoir une instance sur laquelle on peut, après, faire des choses intéressantes.
 
-Ecrire un code dans Lexer.java de tel façon que l'exmple ci-dessous fonctionne. 
+Ecrire un code dans Lexer.java de telle façon que l'exemple ci-dessous fonctionne. 
 ```java
 var lexer = Lexer.create();
 System.out.println(lexer.tryParse("a_keyword").isEmpty());  // affiche true  
@@ -48,8 +50,8 @@ Vérifier que les [tests unitaires](https://github.com/forax/kata-restrospective
 
 ## Question 2
 
-On va maintenant créer une seconde implantantation de Lexer (avec une méthode `from`) qui utilise une expression régulière ayant un groupe et
-qui renvoie le contenu du texte capturé par le groupe si le texte verifie l'expression régulière ou rien sinon.
+On va maintenant créer une seconde implémentation de Lexer (avec une méthode `from`) qui utilise une expression régulière ayant un groupe et
+qui renvoie le contenu du texte capturé par le groupe si le texte vérifie l'expression régulière ou rien sinon.
 
 Par exemple,
 ```java
@@ -58,21 +60,21 @@ System.out.println(lexer.tryParse("zoo").orElseThrow());  // affiche zo
 System.out.println(lexer.tryParse("bar").isEmpty);  // affiche vrai
 ```
 
-et comme demander à l'utilisateur de faire des Pattern.compile à chaque fois, c'est pas terrible, on va ajouter une surchage à `from`
+et comme demander à l'utilisateur de faire des Pattern.compile à chaque fois, c'est pas terrible, on va ajouter une surcharge à `from`
 pour que le code ci-dessus marche en faisant un `Lexer.from("([a-z]o)o")` directement.
 
 Vérifier que les tests unitaires marqués Q2 passent, sinon modifier votre code en conséquence.
-Note: vous pouvez en même temps admirer comment on écrit en [JUnit 5](https://junit.org/junit5/docs/current/user-guide/#writing-tests-parameterized-tests) des tests qui marche sur plusieurs implantations (ici from(Pattern) et from(String)).
+Note: vous pouvez en même temps admirer comment on écrit en [JUnit 5](https://junit.org/junit5/docs/current/user-guide/#writing-tests-parameterized-tests) des tests qui marchent sur plusieurs implémentations (ici from(Pattern) et from(String)).
 
 
 ## Question 3
 
-Renvoyer une chaine de caractère lorsque l'on reconnait une expression régulière c'est bien mais renvoyer directement sa valeur
+Renvoyer une chaîne de caractères lorsque l'on reconnaît une expression régulière c'est bien mais renvoyer directement sa valeur
 (un entier si le motif est un entier, une date si le motif est une date, etc) c'est mieux.
 
-L'idée ici est que l'on a déjà un Lexer qui reconnait et extrait un morceau de texte, pour transformer le texte en une valeur,
-il suffit de demander à l'utilisateur de donner une fonction qui prend une chaine de caractère et renvoie la valeur.
-Habituellement, la méthode qui prend une fonction en paramètre pour transformer la valeur qui est à l'intérieur s'appel <tt>map</tt>.
+L'idée ici est que l'on a déjà un Lexer qui reconnaît et extrait un morceau de texte, pour transformer le texte en une valeur,
+il suffit de demander à l'utilisateur de donner une fonction qui prend une chaîne de caractères et renvoie la valeur.
+Habituellement, la méthode qui prend une fonction en paramètre pour transformer la valeur qui est à l'intérieur s'appelle <tt>map</tt>.
 
 ```java
 var lexer = Lexer.from("([0-9]+)").map(Integer::parseInt);
@@ -84,9 +86,9 @@ Vérifier que les tests unitaires marqués Q3 passent, sinon modifier votre code
 
 ## Question 4
 
-On cherche maintenant à reconnaitre non pas un seul token, mais plusieurs, il nous faut donc une façon de combiner deux Lexer.
+On cherche maintenant à reconnaître non pas un seul token, mais plusieurs, il nous faut donc une façon de combiner deux Lexer.
 On se propose d'ajouter une méthode <tt>or</tt> qui prend en paramètre un Lexer et renvoie un nouveau Lexer.
-Le lexer renvoyé demande au premier lexer d'essayer de reconnaitre le texte et
+Le lexer renvoyé demande au premier lexer d'essayer de reconnaître le texte et
 si celui-ci n'est pas reconnu demande au second Lexer pris en paramètre de faire la même chose. 
 
 ```java
@@ -118,6 +120,6 @@ Vérifier que les tests unitaires marqués Q5 passent, sinon modifier votre code
 
 ## Et la suite
 
-Félicitation vous avez réussi la première partie du kata.
-Une fois que vous êtes content de votre code, vous pouvez passer à la [Partie 2](kata-part2.md).
+Félicitations ! Vous avez réussi la première partie du kata.
+Une fois que vous êtes content(e) de votre code, vous pouvez passer à la [Partie 2](kata-part2.md).
 


### PR DESCRIPTION
Rémi, 

quelques corrections dans les differents fichiers d'instruction.

Si tu veux pas des modifications concernant 'implémenter' vs 'implanter' je peux comprendre mais je ne pense pas être tout seul à ne pas utiliser (voir comprendre) 'implanter' dans le cadre de classes répondant à un contrat d'API : http://www.academie-francaise.fr/implementer